### PR TITLE
cmake build improvements: dependency paths

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,7 @@ ADD_EXECUTABLE(emas
 	writers.c
 )
 
+include_directories(${EMELF_INCLUDE_DIRS} ${EMAWP_INCLUDE_DIRS})
 TARGET_LINK_LIBRARIES(emas ${EMELF_LIBRARIES} ${EMAWP_LIBRARIES})
 
 install(TARGETS emas


### PR DESCRIPTION
- actually use cmake dependency configuration
- update POSIX standards where necessary
- provide POSIX exceptions where necessary
- make sure em400 builds on FreeBSD

Dependency paths has been checked with random
installation paths using conf.sh from

  https://github.com/saper/bootstrap400